### PR TITLE
Set $name argument to 'mailchimp' in constructor

### DIFF
--- a/Model/Logger/Logger.php
+++ b/Model/Logger/Logger.php
@@ -13,6 +13,15 @@ namespace Ebizmarts\MailChimp\Model\Logger;
 
 class Logger extends \Monolog\Logger
 {
+    /**
+     * @param string             $name       The logging channel
+     * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
+     * @param callable[]         $processors Optional array of processors
+     */
+    public function __construct($name = 'mailchimp', array $handlers = array(), array $processors = array())
+    {
+        parent::__construct($name, $handlers, $processors);
+    }
 
     public function mailchimpLog($message, $file)
     {


### PR DESCRIPTION
Fixes BadMethodCallException in Ebizmarts\MailChimp\Model\Logger\Logger due to required parameter $name not getting passed. See: https://github.com/mailchimp/mc-magento2/issues/583